### PR TITLE
Fix attribution text

### DIFF
--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -935,7 +935,7 @@ export const serve_rendered = {
             }
 
             // override attribution text
-            if (req.query.attributionText) {
+            if ('attributionText' in req.query) {
               item.staticAttributionText = req.query.attributionText;
             }
 


### PR DESCRIPTION
Check whether field has value instead.

We're having an issue where

`item.staticAttributionText` remembers the previous `staticAttributionText` for some reason, and this PR just allows us to clear the value using

`&attributionText=`